### PR TITLE
Fix translator stripping types ending with 'y' or 'p'

### DIFF
--- a/translator/hot/translate_node_templates.py
+++ b/translator/hot/translate_node_templates.py
@@ -91,7 +91,9 @@ def _load_classes(locations, classes):
             if f == 'tosca_block_storage_attachment.py':
                 continue
 
-            mod_name = cls_path + '/' + f.strip('.py')
+            if f.endswith('.py'):
+                f = f[:-3]
+            mod_name = cls_path + '/' + f
             mod_name = mod_name.replace('/', '.')
             try:
                 mod = importlib.import_module(mod_name)


### PR DESCRIPTION
When creating a new Tosca type (i.e. tosca_vulnerability), Heat translator stripped the final y since it used `f.strip('.py')`.

See [this](https://stackoverflow.com/questions/1038824/how-do-i-remove-a-substring-from-the-end-of-a-string-in-python) for an example.